### PR TITLE
Store Order Total on Orders Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@
 .DS_Store
 /coverage
 # Ignore secrets.yml file
-
-db/schema.rb

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 .DS_Store
 /coverage
 # Ignore secrets.yml file
+
+db/schema.rb

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,16 +6,17 @@ class Order < ApplicationRecord
 
   enum status: ["ordered", "paid", "cancelled", "completed"]
 
-  def total_price
-    items.sum(:price)
+  def update_total_price
+    update(total_price: order_items.sum(:total_price))
   end
 
   def add(item_hash)
     item_hash.each do |item, quantity|
       items << item
       order_item = OrderItem.find_by(order: self, item_id: item.id)
-      order_item.update(quantity: quantity)
+      order_item.capture_transaction_details(quantity)
     end
+    update_total_price
   end
 
   def date

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,10 +2,8 @@ class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
 
-  before_save :calculate_total_price
-
-  def calculate_total_price
-    self.total_price = self.quantity * self.unit_price if self.quantity
+  def capture_transaction_details(quantity)
+    update(quantity: quantity, unit_price: item.price, total_price: quantity * item.price)
   end
 
   def self.sum_quantity

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,6 +2,12 @@ class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
 
+  before_save :calculate_total_price
+
+  def calculate_total_price
+    self.total_price = self.quantity * self.unit_price if self.quantity
+  end
+
   def self.sum_quantity
     group(:item_id)
   end

--- a/db/migrate/20171213210609_add_total_price_to_orders.rb
+++ b/db/migrate/20171213210609_add_total_price_to_orders.rb
@@ -1,0 +1,5 @@
+class AddTotalPriceToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :total_price, :float
+  end
+end

--- a/db/migrate/20171213211302_add_unit_price_to_order_items.rb
+++ b/db/migrate/20171213211302_add_unit_price_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddUnitPriceToOrderItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :unit_price, :float
+  end
+end

--- a/db/migrate/20171214001153_add_total_price_to_order_items.rb
+++ b/db/migrate/20171214001153_add_total_price_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddTotalPriceToOrderItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :total_price, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213211302) do
+ActiveRecord::Schema.define(version: 20171214001153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20171213211302) do
     t.datetime "updated_at", null: false
     t.integer "quantity"
     t.float "unit_price"
+    t.float "total_price"
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213210609) do
+ActiveRecord::Schema.define(version: 20171213211302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20171213210609) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "quantity"
+    t.float "unit_price"
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170918203915) do
+ActiveRecord::Schema.define(version: 20171213210609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20170918203915) do
     t.string "image_content_type"
     t.integer "image_file_size"
     t.datetime "image_updated_at"
+    t.float "total_price"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     item
     order
     quantity 1
+    unit_price { item.price }
   end
 end

--- a/spec/models/order_items_spec.rb
+++ b/spec/models/order_items_spec.rb
@@ -1,19 +1,13 @@
 require 'rails_helper'
 
 describe OrderItem do
-  describe "attributes" do
-    it "calculates the total_price when given a quantity and unit_price" do
-      order_item = create(:order_item, quantity: 1, unit_price: 0.25)
-      expect(order_item.total_price).to eq 0.25
-    end
-  end
-
   describe "order item methods" do
     it "returns the quantity for an item associated with an order" do
       item_1 = create(:item)
       item_2 = create(:item)
       order_1 = create(:order, items: [item_1, item_2])
       order_2 = create(:order, items: [item_1])
+
       expected_result = {item_1.id => 2, item_2.id => 1}
       quantity_hash = OrderItem.sum_quantity.count
       expect(quantity_hash).to eq(expected_result)

--- a/spec/models/order_items_spec.rb
+++ b/spec/models/order_items_spec.rb
@@ -1,49 +1,58 @@
 require 'rails_helper'
 
-describe "order item methods" do
-  it "returns the quantity for an item associated with an order" do
-    item_1 = create(:item)
-    item_2 = create(:item)
-    order_1 = create(:order, items: [item_1, item_2])
-    order_2 = create(:order, items: [item_1])
-    expected_result = {item_1.id => 2, item_2.id => 1}
-    quantity_hash = OrderItem.sum_quantity.count
-    expect(quantity_hash).to eq(expected_result)
+describe OrderItem do
+  describe "attributes" do
+    it "calculates the total_price when given a quantity and unit_price" do
+      order_item = create(:order_item, quantity: 1, unit_price: 0.25)
+      expect(order_item.total_price).to eq 0.25
+    end
   end
 
-  it "can return top three items" do
-    item_1 = create(:item)
-    item_2 = create(:item)
-    item_3 = create(:item)
-    item_4 = create(:item)
-    order_1 = create(:order)
-    order_2 = create(:order)
-
-    2.times do
-      order_1.items << item_1
-      order_2.items << item_2
-      order_2.items << item_4
+  describe "order item methods" do
+    it "returns the quantity for an item associated with an order" do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      order_1 = create(:order, items: [item_1, item_2])
+      order_2 = create(:order, items: [item_1])
+      expected_result = {item_1.id => 2, item_2.id => 1}
+      quantity_hash = OrderItem.sum_quantity.count
+      expect(quantity_hash).to eq(expected_result)
     end
 
-    order_2.items << item_3
+    it "can return top three items" do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      item_3 = create(:item)
+      item_4 = create(:item)
+      order_1 = create(:order)
+      order_2 = create(:order)
 
-    top_items = OrderItem.top_three_items
-    expect(top_items.count).to eq(3)
-    expect(top_items).to include(item_1)
-    expect(top_items).to include(item_2)
-    expect(top_items).to include(item_4)
-    expect(top_items).to_not include(item_3)
-  end
+      2.times do
+        order_1.items << item_1
+        order_2.items << item_2
+        order_2.items << item_4
+      end
 
-  it "can average quantity" do
-    item_1 = create(:item)
-    item_2 = create(:item)
-    order_1 = create(:order)
-    order_2 = create(:order)
+      order_2.items << item_3
 
-    create(:order_item, item: item_1, quantity: 1, order: order_1)
-    create(:order_item, item: item_2, quantity: 3, order: order_2)
+      top_items = OrderItem.top_three_items
+      expect(top_items.count).to eq(3)
+      expect(top_items).to include(item_1)
+      expect(top_items).to include(item_2)
+      expect(top_items).to include(item_4)
+      expect(top_items).to_not include(item_3)
+    end
 
-    expect(OrderItem.average_quantity).to eq(2)
+    it "can average quantity" do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      order_1 = create(:order)
+      order_2 = create(:order)
+
+      create(:order_item, item: item_1, quantity: 1, order: order_1)
+      create(:order_item, item: item_2, quantity: 3, order: order_2)
+
+      expect(OrderItem.average_quantity).to eq(2)
+    end
   end
 end

--- a/spec/models/orders_spec.rb
+++ b/spec/models/orders_spec.rb
@@ -31,18 +31,35 @@ RSpec.describe Order do
   end
 
   describe "instance methods" do
-    it "can return total price of items" do
-      gob = create(:user)
-      order = create(:order, status: "ordered", user: gob)
-      category = create(:category)
+    it "can return total price of the order" do
+      order = create(:order, status: "ordered")
       item_1 = create(:item, title: "Dove", price: 10.00)
       item_2 = create(:item, title: "Seal", price: 1.00)
-      item_not_included = create(:item, title: "Banana Stand", price: 100.00)
 
-      order.items << item_1
-      order.items  << item_2
+      item_hash = {}
+      item_hash[item_1] = 1
+      item_hash[item_2] = 1
+      order.add(item_hash)
 
       expect(order.total_price).to eq(11.0)
+    end
+
+    context "order price should not change when an item price changes" do
+      it "returns correct total_price after an item price changes" do
+        order = create(:order, status: "ordered")
+        item = create(:item, title: "Dove", price: 10.00)
+
+        item_hash = {}
+        item_hash[item] = 1
+        order.add(item_hash)
+
+        expect(order.total_price).to eq(10.00)
+
+        item.update(price: 12.00)
+
+        expect(order.total_price).to eq(10.00)
+        expect(order.total_price).to_not eq(12.00)
+      end
     end
 
     it "can add an item" do

--- a/spec/models/orders_spec.rb
+++ b/spec/models/orders_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Order do
       end
     end
   end
-  describe 'realtionships' do
+  describe 'relationships' do
     it 'belongs to a user' do
       order = build(:order)
       expect(order).to respond_to(:user)


### PR DESCRIPTION
#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153568558
#### What does this PR do?
This PR stores the total of an order on the orders table by finding the sum of the order_items associated with the order. Previously, the total for an order referenced the price of the items associated with the order, but this was prone to errors if the item price changed from the original.

This PR also adds unit_price and total_price to the order_items table in order to facilitate calculating an order's total.

#### Where should the reviewer start?
- app/models/order.rb to review the add(item_hash) method. It now captures the transaction details for an order_item and saves this info in the database. It also references update_total_price which adds an order's total_price to the database.
- spec/models/orders_spec.rb to view the total price of an order with two items and then "returns correct total_price after an item price changes" to test if the order total changes.
- app/models/order_item.rb to view capture_transaction_details(quantity) that saves order_item info  in the database

#### How should this be manually tested?
Spin up the server, add items to the cart, and click checkout. Then go to rails console to find the last order (order = Order.last) and see if the total_price is stored on this object (order.total_price). Then view the order_items associated with this order (order.order_items). The unit_price and total_price should be stored on this object (order.order_items.first.unit_price, order.order_items.first.total_price).

#### Any background context you want to provide?
When creating order_items in the test suite, the quantity was always set to nil. This happens because the quantity for an order_item record is set in orders#new when order.add(item_hash) is called; something about this doesn't feel great, but I made the decision to keep this same structure to avoid yak shaving.

The add(item_hash) method also feels odd because it relies on the cart to find the Item object from the database and then set this as the key in the items_hash where the value is the quantity.

#### What are the relevant story numbers?
153568558
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
YES! There are 3 migrations with this PR to add total_price to orders, unit_price on order_items, and total_price on order_items.
  - Do Environment Variables need to be set?
No.
  - Any other deploy steps?
No.
