### PR TITLE
Update Category Routes to '/categories/category-name'

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
 	def show
-			@category = Category.friendly.find(params[:category])
+		@category = Category.friendly.find(params[:category])
 	end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,6 @@ Rails.application.routes.draw do
   delete '/cart', :to => 'carts#destroy'
   resources :carts, only: [:index, :create, :destroy]
 
-  get '/:category', to: 'categories#show', param: :slug, as: "category"
+  resources :categories, only: [:show], param: :category
 
 end

--- a/spec/features/guest_user/views/visitor_can_visit_categories_show_spec.rb
+++ b/spec/features/guest_user/views/visitor_can_visit_categories_show_spec.rb
@@ -1,17 +1,29 @@
 require 'rails_helper'
 
-describe "As a visitor can visit category show page" do
-  it "can visit category show page" do
-    magic = create(:category, title: "Magic")
-    sci_fi = create(:category, title: "Sci-Fi")
-    create(:item, title: "Dove", category: magic)
-    create(:item, title: "Light Saber", category: sci_fi)
+describe "As a visitor I can visit category show page" do
+  context "with a valid URI /categories/category_name" do
+    it "and see a list of all active items for the category" do
+      magic = create(:category, title: "Magic")
+      sci_fi = create(:category, title: "Sci-Fi")
+      create(:item, title: "Dove", category: magic)
+      create(:item, title: "Rabbit", category: magic)
+      create(:item, title: "Light Saber", category: sci_fi)
 
-    visit '/magic'
+      visit '/categories/magic'
 
-    within(".items") do
-      expect(page).to have_content("Dove")
-      expect(page).to_not have_content("Light Saber")
+      within(".items") do
+        expect(page).to have_content("Dove")
+        expect(page).to have_content("Rabbit")
+        expect(page).to_not have_content("Light Saber")
+      end
+    end
+  end
+
+  context "with invalid URI /category_name" do
+    it "and I see a 404 error" do
+      create(:category, title: "Magic")
+
+      expect { visit '/magic' }.to raise_error(ActionController::RoutingError)
     end
   end
 end

--- a/spec/features/user/views/user_can_visit_category_show_spec.rb
+++ b/spec/features/user/views/user_can_visit_category_show_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
-RSpec.describe "As a visitor can visit category show page" do
-    it " can visit category show page" do
-      category = create(:category)
-      item = create(:item, category: category)
 
-      visit category_path(category)
-    end
+RSpec.describe "As a visitor can visit category show page" do
+  it " can visit category show page" do
+    category = create(:category)
+
+    visit category_path(category)
+
+    expect(current_path).to eq("/categories/#{category.slug}")
+  end
 end


### PR DESCRIPTION
#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153568561
#### What does this PR do?
This PR changes the routes for categories#show to be '/categories/category-name' instead of '/category-name'.

#### Where should the reviewer start?
config/routes.rb to see the route. It is now nested under the categories resource.

spec/features/guest_user/views/visitor_can_visit_categories_show_spec.rb to see the test coverage for both a happy and sad path.

spec/features/user/views/user_can_visit_category_show_spec.rb to view the updated path assertion.

app/controllers/categories_controller.rb fixes fixes the tabbing to be 2 spaces instead of 4.

#### How should this be manually tested?
Spin up the server, click on a category from the dropdown, and the path should be '/categories/category-name'

#### Any background context you want to provide?
This change is necessary for a future story about visiting an active store. The path for visiting the active store will be '/store-name', so we needed to add categories to the URI in order to prevent any path resolution issues.

#### What are the relevant story numbers?
153568561
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
NO
  - Do Environment Variables need to be set?
NO
  - Any other deploy steps?
NO
