### PR TITLE
Store mgr setup

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,10 @@ class User < ApplicationRecord
     roles.exists?(name: 'Store Admin')
   end
 
+  def store_manager?
+    roles.exists?(name: 'Store Manager')
+  end
+
   def self.user_orders
     group(:email).joins(:orders).count
   end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -6,4 +6,8 @@ FactoryBot.define do
   factory :store_admin, class: Role do
     name "Store Admin"
   end
+
+  factory :store_manager, class: Role do
+    name "Store Manager"
+  end
 end

--- a/spec/features/admin/store_manager_can_sign_in_spec.rb
+++ b/spec/features/admin/store_manager_can_sign_in_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe 'An authenticated store manager' do
+RSpec.feature 'An authenticated store manager' do
   let(:admin) { create(:admin) }
   let(:role) { create(:store_manager) }
 
-  it 'can visit the log in path and sign in' do
+  scenario 'can visit the log in path and sign in' do
     admin.roles << role
     expect(admin.roles).to include(role)
 

--- a/spec/features/admin/store_manager_can_sign_in_spec.rb
+++ b/spec/features/admin/store_manager_can_sign_in_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'An authenticated store manager' do
+  let(:admin) { create(:admin) }
+  let(:role) { create(:store_manager) }
+
+  it 'can visit the log in path and sign in' do
+    admin.roles << role
+    expect(admin.roles).to include(role)
+
+    visit login_path
+
+    expect(current_path).to eq('/login')
+    expect(page).to have_content("Email")
+    expect(page).to have_field('session[email]')
+    expect(page).to have_content("Password")
+    expect(page).to have_field('session[password]')
+
+    fill_in 'session[email]', with: admin.email
+    fill_in 'session[password]', with: admin.password
+
+    click_button 'Login'
+
+    expect(current_path).to eq(admin_dashboard_index_path)
+    expect(page).to have_content("Admin Dashboard")
+    expect(page).to have_content("You're logged in as a Store Manager.")
+  end
+end


### PR DESCRIPTION
### 2 Points
Feature requires 2 reviewers

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153688795

#### What does this PR do?
Enables user whose role includes that of a store manager, be directed to /admin/dashboard after logging in, and sees indication of their status.

All tests passing
![image](https://user-images.githubusercontent.com/27023122/34023706-a27dc786-e103-11e7-8813-0d10df93b074.png)


#### Where should the reviewer start?
spec/features/admin/store_manager_can_sign_in_spec.rb

#### How should this be manually tested?
Unnecessary

#### Any background context you want to provide?
May want to `Role.create(name: 'Store Manager')` within rails console to manually test this feature

#### What are the relevant story numbers?
153688795

#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No

