### PR TITLE
User Visits Active Store

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -18,6 +18,10 @@ class Store < ApplicationRecord
     user_roles.create(user: user, role: role)
   end
 
+  def active_items
+    items.where(condition: "active")
+  end
+
   private
 
     def generate_url

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @store.name %></h1>
 
-<% @store.items.each do |item| %>
+<% @store.active_items.each do |item| %>
   <p><%= item.title %></p>
   <p><%= image_tag(item.image) %></p>
   <p><%= item.price %></p>

--- a/spec/features/user/stores/user_sees_stores_active_items_spec.rb
+++ b/spec/features/user/stores/user_sees_stores_active_items_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "As a logged in user when I visit a store" do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       user.roles << role
 
-      store = create(:store)
+      store = create(:store, status: "active")
       item_1 = create(:item, store: store, condition: "active")
       item_2 = create(:item, store: store, condition: "active")
       item_3 = create(:item, store: store, condition: "retired")
@@ -26,8 +26,8 @@ RSpec.feature "As a logged in user when I visit a store" do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
         user.roles << role
 
-        store_1 = create(:store)
-        store_2 = create(:store)
+        store_1 = create(:store, status: "active")
+        store_2 = create(:store, status: "active")
         item_1 = create(:item, store: store_1)
         item_2 = create(:item, store: store_2)
 

--- a/spec/features/user/stores/user_sees_stores_active_items_spec.rb
+++ b/spec/features/user/stores/user_sees_stores_active_items_spec.rb
@@ -39,10 +39,3 @@ RSpec.feature "As a logged in user when I visit a store" do
     end
   end
 end
-
-# Background: There is an active company with a name of "Vandelay Industries" with 2 active items and 1 inactive item. There is also 1 item that isn't associated with this store.
-#
-# As a logged in user
-# When I visit "/vandelay-industries"
-# Then I should see a list of all active items for this store
-# And I should not see inactive items or items for other stores

--- a/spec/features/user/stores/user_sees_stores_active_items_spec.rb
+++ b/spec/features/user/stores/user_sees_stores_active_items_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature "As a logged in user when I visit a store" do
+  context "with active and inactive items" do
+    let(:user) { create(:user) }
+    let(:role) { create(:registered_user) }
+
+    scenario "I see a list of all active items and no inactive items" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      user.roles << role
+
+      store = create(:store)
+      item_1 = create(:item, store: store, condition: "active")
+      item_2 = create(:item, store: store, condition: "active")
+      item_3 = create(:item, store: store, condition: "retired")
+
+      visit store_path(store.url)
+
+      expect(page).to have_content(item_1.title)
+      expect(page).to have_content(item_2.title)
+      expect(page).to_not have_content(item_3.title)
+    end
+
+    context "and another store exists with active items" do
+      scenario "I only see items from the current store and not the other store" do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        user.roles << role
+
+        store_1 = create(:store)
+        store_2 = create(:store)
+        item_1 = create(:item, store: store_1)
+        item_2 = create(:item, store: store_2)
+
+        visit store_path(store_1.url)
+
+        expect(page).to have_content(item_1.title)
+        expect(page).to_not have_content(item_2.title)
+      end
+    end
+  end
+end
+
+# Background: There is an active company with a name of "Vandelay Industries" with 2 active items and 1 inactive item. There is also 1 item that isn't associated with this store.
+#
+# As a logged in user
+# When I visit "/vandelay-industries"
+# Then I should see a list of all active items for this store
+# And I should not see inactive items or items for other stores

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Store do
+  describe "#instance_methods" do
+    describe "#active_items" do
+      let(:store) { create(:store) }
+
+      it "returns only active items" do
+        item_1 = create(:item, store: store, condition: "active")
+        item_2 = create(:item, store: store, condition: "retired")
+
+        expect(store.active_items).to include(item_1)
+        expect(store.active_items).to_not include(item_2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 1 point story: 1 reviewer

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153568562
#### What does this PR do?
This PR adds the functionality to only display active items for a store. It also checks to make sure that another store's items aren't rendered on a store's page.

This PR also creates the store_spec for model testing.

#### Where should the reviewer start?
- spec/features/user/stores/user_sees_stores_active_items_spec.rb

#### How should this be manually tested?
Create a store in the console and create two items for it. One item should have a condition of active and the other item should be retired. Visit the store's page on the server "/store-name", and only the active item should show up.

#### Any background context you want to provide?
none.

#### What are the relevant story numbers?
153568562
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No
