### PR TITLE
User cannot visit an inactive store

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,4 +1,7 @@
 class StoresController < ApplicationController
+
+  before_action :active_store?, only: [:show]
+
   def show
     @store = Store.find_by(url: params[:store])
   end
@@ -20,4 +23,10 @@ class StoresController < ApplicationController
     def store_params
       params.require(:store).permit(:name)
     end
+
+    def active_store?
+      store = Store.find_by(url: params[:store])
+      not_found unless store && store.active?
+    end
+
 end

--- a/spec/features/guest_user/stores/visitor_visits_different_stores_spec.rb
+++ b/spec/features/guest_user/stores/visitor_visits_different_stores_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "As a guest, when I visit '/store-name-1'" do
   it "I see the store name, a list of all items associated to that store, and each items name, price, and 'Add to Cart' button." do
-    stores = create_list(:store, 2)
+    stores = create_list(:store, 2, status: "active")
     items_store_1 = create_list(:item, 2, store: stores.first)
     items_store_2 = create_list(:item, 2, store: stores.last, price: 11.00)
 

--- a/spec/features/guest_user/views/visitor_can_visit_categories_show_spec.rb
+++ b/spec/features/guest_user/views/visitor_can_visit_categories_show_spec.rb
@@ -23,7 +23,7 @@ describe "As a visitor I can visit category show page" do
     it "and I see an error message" do
       create(:category, title: "Magic")
 
-      expect { visit '/magic' }.to raise_error(ActionView::Template::Error)
+      expect { visit '/magic' }.to raise_error(ActionController::RoutingError)
     end
   end
 end

--- a/spec/features/user/stores/user_cannot_visit_inactive_store_spec.rb
+++ b/spec/features/user/stores/user_cannot_visit_inactive_store_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.feature "As a logged in user" do
+  context "when I visit an inactive store path" do
+    let(:user) { create(:user) }
+    let(:role) { create(:registered_user) }
+
+    context "because the store is pending" do
+      it "renders a 404 error" do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        user.roles << role
+
+        store = create(:store, name: "Nocturne", status: "pending")
+
+        expect {
+          visit store_path(store.url)
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "because the store is suspended" do
+      it "renders a 404 error" do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        user.roles << role
+
+        store = create(:store, name: "Nocturne", status: "pending")
+
+        expect {
+          visit store_path(store.url)
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 1 point: 1 reviewer

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153568564

#### What does this PR do?
This PR checks if a store is active and renders a 404 if the store is inactive (pending or suspended).

It accomplishes this task by applying a before_action to check if a store is active when hitting stores#show.

#### Where should the reviewer start?
spec/features/user/stores/user_cannot_visit_inactive_store_spec.rb

#### How should this be manually tested?
create a store and try to visit the store in the browser. An error message should appear with "Not found" because the store, by default, is pending.

create another store with a status of suspended and try to visit it in the browser. An error message should appear.

#### Any background context you want to provide?
#### What are the relevant story numbers?
153568564
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
NO
  - Do Environment Variables need to be set?
NO
  - Any other deploy steps?
NO

