### PR TITLE
Approve store

### DIFF
--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,0 +1,14 @@
+class Admin::StoresController < ApplicationController
+  before_action :require_admin
+
+  def index
+    @stores = Store.all
+  end
+
+  def update
+    store = Store.find(params[:id])
+    store.update_status(params[:status])
+
+    redirect_to admin_stores_path
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,8 @@ class ApplicationController < ActionController::Base
 
 
   def current_admin?
-    platform_admin_role = Role.find_by(name: "Platform Admin")
-
     (current_user && current_user.admin?) ||
-      (current_user && current_user.roles.include?(platform_admin_role))
+      (current_user && current_user.platform_admin?)
   end
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,10 @@ class ApplicationController < ActionController::Base
 
 
   def current_admin?
-    current_user && current_user.admin?
+    platform_admin_role = Role.find_by(name: "Platform Admin")
+
+    (current_user && current_user.admin?) ||
+      (current_user && current_user.roles.include?(platform_admin_role))
   end
 
 

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -22,6 +22,13 @@ class Store < ApplicationRecord
     items.where(condition: "active")
   end
 
+  def update_status(status)
+    store_admin_role = Role.find_by(name: "Store Admin")
+
+    user_roles.first.update(role: store_admin_role)
+    update(status: status)
+  end
+
   private
 
     def generate_url

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "View Items", admin_items_path, class: "nav-item nav-link" %>
     <%= link_to "Update Account", edit_user_path(current_user), class: "nav-item nav-link" %>
     <%= link_to "View Analytics", admin_analytics_path, class: "nav-item nav-link" %>
-
+    <%= link_to "Stores", admin_stores_path, class: "nav-item nav-link" %>
     </div>
   </nav>
   <div class="container">

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,0 +1,94 @@
+<div class="container">
+  <h3>Admin Dashboard</h3>
+  <nav class="nav nav-tabs" id="myTab" role="tablist">
+    <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab" aria-controls="nav-home" aria-expanded="true">View Orders</a>
+    <%= link_to "View Items", admin_items_path, class: "nav-item nav-link" %>
+    <%= link_to "Update Account", edit_user_path(current_user), class: "nav-item nav-link" %>
+    <%= link_to "View Analytics", admin_analytics_path, class: "nav-item nav-link" %>
+    <%= link_to "Stores", admin_stores_path, class: "nav-item nav-link" %>
+  </nav>
+</div>
+
+<div class="container">
+  <div class="tab-content" id="nav-tabContent">
+    <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
+ 	      <table class="table table-hover pending_stores">
+ 	         <thead>
+             <h5>Pending Stores</h5>
+ 	            <tr>
+         	      <th>Store #</th>
+         	      <th>Store Name</th>
+         	      <th>Store Status</th>
+ 		      			<th></th>
+ 		      			<th></th>
+ 	            </tr>
+ 	          </thead>
+            <tbody>
+             <% @stores.pending.each do |store| %>
+               <tr class="store<%= store.id %>">
+                 <th scope="row">
+                   <%= store.id %>
+                 </th>
+                 <td><%= store.name %></td>
+                 <td class="status"><%= store.status.capitalize %></td>
+                 <td><%= link_to "Approve", admin_store_path(store, status: "active"), method: :put, class: "badge badge-success" %></td>
+                 <td><%= link_to "Reject", root_path, method: :put, class: "badge badge-warning" %></td>
+               </tr>
+             <% end %>
+            </tbody>
+        </table>
+        <table class="table table-hover active_stores">
+ 	         <thead>
+             <h5>Active Stores</h5>
+ 	            <tr>
+         	      <th>Store #</th>
+         	      <th>Store Name</th>
+         	      <th>Store Status</th>
+ 		      			<th></th>
+ 		      			<th></th>
+ 	            </tr>
+ 	          </thead>
+            <tbody>
+             <% @stores.active.each do |store| %>
+               <tr class="store<%= store.id %>">
+                 <th scope="row">
+                   <%= store.id %>
+                 </th>
+                 <td><%= store.name %></td>
+                 <td class="status"><%= store.status.capitalize %></td>
+                 <td><%= link_to "Suspend", root_path, method: :put, class: "badge badge-warning" %></td>
+                 <td></td>
+               </tr>
+             <% end %>
+            </tbody>
+        </table>
+        <table class="table table-hover suspended_stores">
+ 	         <thead>
+             <h5>Suspended Stores</h5>
+ 	            <tr>
+         	      <th>Store #</th>
+         	      <th>Store Name</th>
+         	      <th>Store Status</th>
+ 		      			<th></th>
+ 		      			<th></th>
+ 	            </tr>
+ 	          </thead>
+            <tbody>
+             <% @stores.suspended.each do |store| %>
+               <tr class="store<%= store.id %>">
+                 <th scope="row">
+                   <%= store.id %>
+                 </th>
+                 <td><%= store.name %></td>
+                 <td class="status"><%= store.status.capitalize %></td>
+                 <td><%= link_to "Reactivate", root_path, method: :put, class: "badge badge-success" %></td>
+               </tr>
+             <% end %>
+            </tbody>
+        </table>
+      </div>
+    </div>
+  <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">...</div>
+  <div class="tab-pane fade" id="nav-dropdown1" role="tabpanel" aria-labelledby="nav-dropdown1-tab">...</div>
+  <div class="tab-pane fade" id="nav-dropdown2" role="tabpanel" aria-labelledby="nav-dropdown2-tab">...</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
     resources :dashboard, only: [:index]
     resources :items, only: [:index, :edit, :new, :create, :update]
     resources :analytics, only: [:index]
+    resources :stores, only: [:index, :update]
   end
-
 
   resources :users , only: [:new, :create, :edit, :update]
 

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_role do
+    
+  end
+end

--- a/spec/features/platform_admin/platform_admin_can_approve_pending_store_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_approve_pending_store_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+feature "As a logged in platform admin," do
+  feature "when I visit /admin/dashboard and click 'Stores'" do
+
+    before(:each) do
+      registered_user_role = create(:registered_user)
+      @store_admin = create(:store_admin)
+      platform_admin_role = create(:platform_admin)
+
+      @user = create(:user)
+      @store_1 = create(:store, status: 0)
+      create(:user_role, user: @user, role: registered_user_role, store: @store_1)
+
+      platform_admin = create(:user)
+      platform_admin.roles << platform_admin_role
+
+      @store_2 = create(:store, status: 1)
+      @store_3 = create(:store, status: 2)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(platform_admin)
+
+      visit "/admin/dashboard"
+      click_on "Stores"
+    end
+
+    scenario  "I should see a list of stores divided by 'pending', 'active', and 'suspended' tabs" do
+      within(".pending_stores") do
+        expect(page).to have_content(@store_1.id)
+        expect(page).to have_content(@store_1.name)
+        expect(page).to have_content(@store_1.status.capitalize)
+        expect(page).to have_link("Reject")
+        expect(page).to have_link("Approve")
+      end
+      within(".active_stores") do
+        expect(page).to have_content(@store_2.id)
+        expect(page).to have_content(@store_2.name)
+        expect(page).to have_content(@store_2.status.capitalize)
+        expect(page).to have_link("Suspend")
+      end
+      within(".suspended_stores") do
+        expect(page).to have_content(@store_3.id)
+        expect(page).to have_content(@store_3.name)
+        expect(page).to have_content(@store_3.status.capitalize)
+        expect(page).to have_link("Reactivate")
+      end
+    end
+
+    feature "When I click 'Approve' for the pending company" do
+      scenario "it shows up in the 'active' tab, and the user that requested this store has a role of store admin" do
+        click_on "Approve"
+
+        within(".active_stores") do
+          expect(page).to have_content(@store_1.id)
+          expect(page).to have_content(@store_1.name)
+        end
+
+        expect(@user.roles).to include(@store_admin)
+      end
+    end
+  end
+end

--- a/spec/features/platform_admin/platform_admin_can_approve_pending_store_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_approve_pending_store_spec.rb
@@ -2,60 +2,64 @@ require 'rails_helper'
 
 feature "As a logged in platform admin," do
   feature "when I visit /admin/dashboard and click 'Stores'" do
+    let(:registered_user_role) { create(:registered_user) }
+    let(:store_admin_role) { create(:store_admin) }
+    let(:platform_admin_role) { create(:platform_admin) }
+
+    let(:user) { create(:user) }
+    let(:platform_admin) { create(:user) }
+
+    let(:store_1) { create(:store, status: 0) }
+    let(:store_2) { create(:store, status: 1) }
+    let(:store_3) { create(:store, status: 2) }
 
     before(:each) do
-      registered_user_role = create(:registered_user)
-      @store_admin = create(:store_admin)
-      platform_admin_role = create(:platform_admin)
-
-      @user = create(:user)
-      @store_1 = create(:store, status: 0)
-      create(:user_role, user: @user, role: registered_user_role, store: @store_1)
-
-      platform_admin = create(:user)
+      create(:user_role, user: user, role: registered_user_role, store: store_1)
       platform_admin.roles << platform_admin_role
-
-      @store_2 = create(:store, status: 1)
-      @store_3 = create(:store, status: 2)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(platform_admin)
 
       visit "/admin/dashboard"
-      click_on "Stores"
     end
 
     scenario  "I should see a list of stores divided by 'pending', 'active', and 'suspended' tabs" do
+      store_2
+      store_3
+      click_on "Stores"
+
       within(".pending_stores") do
-        expect(page).to have_content(@store_1.id)
-        expect(page).to have_content(@store_1.name)
-        expect(page).to have_content(@store_1.status.capitalize)
+        expect(page).to have_content(store_1.id)
+        expect(page).to have_content(store_1.name)
+        expect(page).to have_content(store_1.status.capitalize)
         expect(page).to have_link("Reject")
         expect(page).to have_link("Approve")
       end
       within(".active_stores") do
-        expect(page).to have_content(@store_2.id)
-        expect(page).to have_content(@store_2.name)
-        expect(page).to have_content(@store_2.status.capitalize)
+        expect(page).to have_content(store_2.id)
+        expect(page).to have_content(store_2.name)
+        expect(page).to have_content(store_2.status.capitalize)
         expect(page).to have_link("Suspend")
       end
       within(".suspended_stores") do
-        expect(page).to have_content(@store_3.id)
-        expect(page).to have_content(@store_3.name)
-        expect(page).to have_content(@store_3.status.capitalize)
+        expect(page).to have_content(store_3.id)
+        expect(page).to have_content(store_3.name)
+        expect(page).to have_content(store_3.status.capitalize)
         expect(page).to have_link("Reactivate")
       end
     end
 
     feature "When I click 'Approve' for the pending company" do
       scenario "it shows up in the 'active' tab, and the user that requested this store has a role of store admin" do
+        store_admin_role
+        click_on "Stores"
         click_on "Approve"
 
         within(".active_stores") do
-          expect(page).to have_content(@store_1.id)
-          expect(page).to have_content(@store_1.name)
+          expect(page).to have_content(store_1.id)
+          expect(page).to have_content(store_1.name)
         end
 
-        expect(@user.roles).to include(@store_admin)
+        expect(user.roles).to include(store_admin_role)
       end
     end
   end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -2,15 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Store do
   describe "#instance_methods" do
-    describe "#active_items" do
-      let(:store) { create(:store) }
+    let(:store) { create(:store) }
 
+    describe "#active_items" do
       it "returns only active items" do
         item_1 = create(:item, store: store, condition: "active")
         item_2 = create(:item, store: store, condition: "retired")
 
         expect(store.active_items).to include(item_1)
         expect(store.active_items).to_not include(item_2)
+      end
+    end
+
+    describe "#update_status(status)" do
+      it "changes the status of a pending store to active" do
+        user = create(:user)
+        registered_user_role = create(:registered_user)
+        store_admin_role = create(:store_admin)
+
+        user_roles = create(:user_role, user: user, role: registered_user_role, store: store)
+        store.update_status("active")
+
+        expect(store.status).to eq("active")
+        expect(user.roles).to include(store_admin_role)
       end
     end
   end


### PR DESCRIPTION
This is a 3 pt. ticket, so 2 reviewers are needed

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153568560

#### What does this PR do?
Platform admin can see admin dashboard, a page of all stores, and update a pending store and that store's owner's status.

#### Where should the reviewer start?
The reviewers should start with the main test. spec/features/platform_admin/platform_admin_can_approve_pending_store_spec.rb
Then, look at commits starting with the second commit (because the first was the first iteration of the test mentioned above). Reviewing by commit order might be the best approach to review.

#### How should this be manually tested?
In console, 
-Create a "Registered User", "Store Admin", and "Platform Admin" roles
-Create a registered user and platform admin (by assigning them roles)
On the website, 
-As the registered user, create a store at "/stores/new"
-As the platform admin, go to your dashboard, click stores, and approve the store
-The store should show up under active
In console, 
-The registered user should now have a role of "Store Admin"

#### Any background context you want to provide?
#### What are the relevant story numbers?
153568560

#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No
