### PR TITLE
User can view all active stores

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -2,6 +2,10 @@ class StoresController < ApplicationController
 
   before_action :active_store?, only: [:show]
 
+  def index
+    @stores = Store.all_active_stores
+  end
+
   def show
     @store = Store.find_by(url: params[:store])
   end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -3,7 +3,7 @@ class StoresController < ApplicationController
   before_action :active_store?, only: [:show]
 
   def index
-    @stores = Store.all_active_stores
+    @stores = Store.active
   end
 
   def show

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -19,7 +19,7 @@ class Store < ApplicationRecord
   end
 
   def active_items
-    items.where(condition: "active")
+    items.active
   end
 
   def update_status(status)
@@ -27,10 +27,6 @@ class Store < ApplicationRecord
 
     user_roles.first.update(role: store_admin_role)
     update(status: status)
-  end
-
-  def self.all_active_stores
-    where(status: "active")
   end
 
   private

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -29,6 +29,10 @@ class Store < ApplicationRecord
     update(status: status)
   end
 
+  def self.all_active_stores
+    where(status: "active")
+  end
+
   private
 
     def generate_url

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -1,0 +1,17 @@
+<body>
+
+  <div class="container">
+    <div class="row">
+      <% @stores.each do |store| %>
+        <div class="center-block">
+          <div class="card border-white" style="width: 15rem;">
+            <div class="card-body">
+              <center><p><strong><%= link_to store.name, store_path(store.url) %></strong></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+</body>

--- a/spec/features/guest_user/stores/visitor_sees_all_stores_spec.rb
+++ b/spec/features/guest_user/stores/visitor_sees_all_stores_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature "As a visitor, when I visit /stores" do
+  before :each do
+    @store_1 = create(:store, status: "active")
+    @store_2 = create(:store, status: "active")
+  end
+
+  scenario "I see all stores" do
+    visit stores_path
+
+    expect(current_path).to eq("/stores")
+
+    expect(page).to have_content(@store_1.name)
+    expect(page).to have_content(@store_2.name)
+  end
+
+  context "with 2 active stores, 1 pending store, and 1 suspended store" do
+    scenario "I only see the active stores" do
+      store_3 = create(:store, status: "pending")
+      store_4 = create(:store, status: "suspended")
+
+      visit stores_path
+
+      expect(page).to have_content(@store_1.name)
+      expect(page).to have_content(@store_2.name)
+      expect(page).to_not have_content(store_3.name)
+      expect(page).to_not have_content(store_4.name)
+    end
+  end
+
+  context "and there are two stores that both have items" do
+    scenario "I only see store info, and I don't see any items" do
+      item_1 = create(:item, store: @store_1)
+      item_2 = create(:item, store: @store_2)
+
+      visit stores_path
+
+      expect(page).to have_content(@store_1.name)
+      expect(page).to_not have_content(item_1.title)
+      expect(page).to_not have_content(item_2.title)
+    end
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Store do
     end
   end
   describe "#instance_methods" do
+    let(:store) { create(:store) }
+    
     describe "#active_items" do
-      let(:store) { create(:store) }
       it "returns only active items" do
         item_1 = create(:item, store: store, condition: "active")
         item_2 = create(:item, store: store, condition: "retired")

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,24 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Store do
-  describe ".class_methods" do
-    describe ".all_active_stores" do
-      it "returns only active stores" do
-        store_1 = create(:store, status: "active")
-        store_2 = create(:store, status: "pending")
-        store_3 = create(:store, status: "suspended")
-
-        active_stores = Store.all_active_stores
-
-        expect(active_stores).to include(store_1)
-        expect(active_stores).to_not include(store_2)
-        expect(active_stores).to_not include(store_3)
-      end
-    end
-  end
   describe "#instance_methods" do
     let(:store) { create(:store) }
-    
+
     describe "#active_items" do
       it "returns only active items" do
         item_1 = create(:item, store: store, condition: "active")

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Store do
-  describe "#instance_methods" do
-    let(:store) { create(:store) }
+  describe ".class_methods" do
+    describe ".all_active_stores" do
+      it "returns only active stores" do
+        store_1 = create(:store, status: "active")
+        store_2 = create(:store, status: "pending")
+        store_3 = create(:store, status: "suspended")
 
+        active_stores = Store.all_active_stores
+
+        expect(active_stores).to include(store_1)
+        expect(active_stores).to_not include(store_2)
+        expect(active_stores).to_not include(store_3)
+      end
+    end
+  end
+  describe "#instance_methods" do
     describe "#active_items" do
+      let(:store) { create(:store) }
       it "returns only active items" do
         item_1 = create(:item, store: store, condition: "active")
         item_2 = create(:item, store: store, condition: "retired")


### PR DESCRIPTION
## 1 point: 1 reviewer

#### Pivotal URL:
https://www.pivotaltracker.com/story/show/153723986

#### What does  this PR do?
This PR allows a user to view all active stores via the "/stores" URI.

#### Where should the reviewer start?
spec/features/guest_user/stores/visitor_sees_all_store_spec.rb
Then view the store_spec for the class method that returns a collection of only active stores.

#### How should this be manually tested?
Create an active store, pending store, and suspended store in the console. Start the server, visit "/stores", and you should only see the active store on the page.

You shouldn't see any information related to items.
 
#### Any background context you want to provide?
none

#### What are the relevant story numbers?
153723986
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No.
  - Do Environment Variables need to be set?
No.
  - Any other deploy steps?
No.
