### PR TITLE
Create migration for store & order_item association with rake task.

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,9 +1,11 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
+  belongs_to :store
+  delegate :store, to: :item
 
   def capture_transaction_details(quantity)
-    update(quantity: quantity, unit_price: item.price, total_price: quantity * item.price)
+    update(quantity: quantity, unit_price: item.price, total_price: quantity * item.price, store: item.store)
   end
 
   def self.sum_quantity

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -2,6 +2,8 @@ class Store < ApplicationRecord
   has_many :user_roles
   has_many :users, through: :user_roles
   has_many :items
+  has_many :order_items
+  has_many :orders, through: :order_items
 
   before_validation :generate_url
 

--- a/db/migrate/20171217174412_add_store_to_order_item.rb
+++ b/db/migrate/20171217174412_add_store_to_order_item.rb
@@ -1,0 +1,5 @@
+class AddStoreToOrderItem < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :order_items, :store, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171216020612) do
+ActiveRecord::Schema.define(version: 20171217174412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,8 +47,10 @@ ActiveRecord::Schema.define(version: 20171216020612) do
     t.integer "quantity"
     t.float "unit_price"
     t.float "total_price"
+    t.bigint "store_id"
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["store_id"], name: "index_order_items_on_store_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -101,6 +103,7 @@ ActiveRecord::Schema.define(version: 20171216020612) do
   add_foreign_key "items", "stores"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "stores"
   add_foreign_key "orders", "users"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "stores"

--- a/lib/tasks/order_items/save_store_info.rake
+++ b/lib/tasks/order_items/save_store_info.rake
@@ -1,0 +1,14 @@
+namespace :order_items do
+  desc "Save store_id on order_item records if not present"
+  task save_store_info: :environment do
+    OrderItem.find_each do |order_item|
+      if order_item.store_id
+        puts "order_item#{order_item.id} already has store_id."
+      else
+        store = order_item.store
+        order_item.update(store: store)
+        puts "order_item#{order_item.id} updated with store #{order_item.store_id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## chore: 1 reviewer

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153724863
https://www.pivotaltracker.com/story/show/153729320


#### What does this PR do?
This PR creates a migration to add store_id to order_items.
This PR creates the rake task to update current order_items with the store_id.

#### Where should the reviewer start?
db/migrate/20171217174412_add_store_to_order_item.rb
db/schema.rb
Then view the models to see the associations (order_item.rb, store.rb)

Then view the rake task to save the store information in the actual order_item record for current order_items.

#### How should this be manually tested?
run the migration and then go into the console to find an order_item. The store_id on the record will be nil, but you can access the store information by calling order_item.store.

Then, run the rake task `$ rake order_items:save_store_info` and now all order_items should have a store_id saved to the record.

#### Any background context you want to provide?
This PR uses the delegate module.  https://apidock.com/rails/Module/delegate

When you call order_item.store it looks for the store information through the item that is already associated on the order_item.

#### What are the relevant story numbers?
153724863
153729320

#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
yes!
  - Do Environment Variables need to be set?
no.
  - Any other deploy steps?
After you've run the  migrations, `$ rake order_items:save_store_info` to save the store_id on the actual order_item.

