### PR TITLE
Platform admin can Reactivate and Suspend Stores

### DIFF
--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -56,7 +56,7 @@
                  </th>
                  <td><%= store.name %></td>
                  <td class="status"><%= store.status.capitalize %></td>
-                 <td><%= link_to "Suspend", root_path, method: :put, class: "badge badge-warning" %></td>
+                 <td><%= link_to "Suspend", admin_store_path(store, status: "suspended"), method: :put, class: "badge badge-warning" %></td>
                  <td></td>
                </tr>
              <% end %>
@@ -81,7 +81,7 @@
                  </th>
                  <td><%= store.name %></td>
                  <td class="status"><%= store.status.capitalize %></td>
-                 <td><%= link_to "Reactivate", root_path, method: :put, class: "badge badge-success" %></td>
+                 <td><%= link_to "Reactivate", admin_store_path(store, status: "active"), method: :put, class: "badge badge-success" %></td>
                </tr>
              <% end %>
             </tbody>

--- a/spec/features/platform_admin/platform_admin_can_suspend_or_reactivate_store_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_suspend_or_reactivate_store_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature "As a logged in platform admin" do
+  feature "when I visit /admin/stores" do
+    let(:store_admin_role) { create(:store_admin)}
+    let(:platform_admin_role) { create(:platform_admin) }
+
+    let(:user) { create(:user) }
+    let(:platform_admin) { create(:user)}
+
+    let(:store_1) { create(:store, status: "active") }
+    let(:store_2) { create(:store, status: "suspended") }
+
+    before(:each) do
+      create(:user_role, user: user, role: store_admin_role, store: store_1)
+      create(:user_role, user: user, role: store_admin_role, store: store_2)
+      create(:user_role, user: platform_admin, role: platform_admin_role)
+      platform_admin.roles << platform_admin_role
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(platform_admin)
+
+      store_1
+      store_2
+
+      visit "/admin/stores"
+    end
+
+    scenario "I can change a store from active to suspended to take it offline" do
+      within(".active_stores") do
+        expect(page).to have_content(store_1.name)
+        click_on "Suspend"
+      end
+
+      expect(current_path).to eq("/admin/stores")
+
+      within(".suspended_stores") do
+        expect(page).to have_content(store_1.name)
+      end
+
+      within(".active_stores") do
+        expect(page).to_not have_content(store_1.name)
+      end
+    end
+
+    scenario "I can change a store from suspended to activated to take it online" do
+      within(".suspended_stores") do
+        expect(page).to have_content(store_2.name)
+        click_on "Reactivate"
+      end
+
+      expect(current_path).to eq("/admin/stores")
+
+      within(".active_stores") do
+        expect(page).to have_content(store_2.name)
+      end
+
+      within(".suspended_stores") do
+        expect(page).to_not have_content(store_2.name)
+      end
+    end
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -26,6 +26,34 @@ RSpec.describe Store do
         expect(store.status).to eq("active")
         expect(user.roles).to include(store_admin_role)
       end
+
+      context "a store is active" do
+        it "changes the status of an active store to suspended" do
+          store_1 = create(:store, status: "active")
+          user = create(:user)
+          store_admin_role = create(:store_admin)
+
+          create(:user_role, user: user, role: store_admin_role, store: store_1)
+
+          store_1.update_status("suspended")
+
+          expect(store_1.status).to eq("suspended")
+        end
+      end
+
+      context "a store is suspended" do
+        it "changes the status of a suspended store to active" do
+          store_2 = create(:store, status: "suspended")
+          user = create(:user)
+          store_admin_role = create(:store_admin)
+
+          create(:user_role, user: user, role: store_admin_role, store: store_2)
+
+          store_2.update_status("active")
+
+          expect(store_2.status).to eq("active")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 1 point: 1 reviewer

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153614800

#### What does this PR do?
This PR allows a platform admin to suspend a store and reactivate a store from 'admin/stores.'

#### Where should the reviewer start?
spec/features/platform_admin/platform_admin_can_suspend_or_reactivate_store_spec.rb

#### How should this be manually tested?
Log in as a platform admin, visit "/stores/new" to create a new store. Then navigate to the dashboard "/admin/dashboard". Approve the store.

Click on the stores tab, and then approve the store (look in the pending column).

Now you can click on the suspend button in the active stores, and it will move the store to the suspended section. Then you can click reactivate to take the store back online.

#### Any background context you want to provide?
If you have stores setup without the appropriate user roles, the status will not update. There is another card that will decouple user_roles updating from the update_status method on stores. https://www.pivotaltracker.com/story/show/153730458

#### What are the relevant story numbers?
153614800

#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No

