### PR TITLE
Platform admin rejects store

### DIFF
--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -7,7 +7,7 @@ class Admin::StoresController < ApplicationController
 
   def update
     store = Store.find(params[:id])
-    store.update_status(params[:status])
+    store.update_status(params[:status], params[:initial_req])
 
     redirect_to admin_stores_path
   end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -22,10 +22,11 @@ class Store < ApplicationRecord
     items.active
   end
 
-  def update_status(status)
-    store_admin_role = Role.find_by(name: "Store Admin")
+  def update_status(status, initial_req = nil)
+    if initial_req
+      promote_creator_to_admin
+    end
 
-    user_roles.first.update(role: store_admin_role)
     update(status: status)
   end
 
@@ -33,5 +34,10 @@ class Store < ApplicationRecord
 
     def generate_url
       self.url = name.parameterize
+    end
+
+    def promote_creator_to_admin
+      store_admin_role = Role.find_by(name: "Store Admin")
+      user_roles.first.update(role: store_admin_role)
     end
 end

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -31,8 +31,8 @@
                  </th>
                  <td><%= store.name %></td>
                  <td class="status"><%= store.status.capitalize %></td>
-                 <td><%= link_to "Approve", admin_store_path(store, status: "active"), method: :put, class: "badge badge-success" %></td>
-                 <td><%= link_to "Reject", root_path, method: :put, class: "badge badge-warning" %></td>
+                 <td><%= link_to "Approve", admin_store_path(store, status: "active", initial_req: true), method: :put, class: "badge badge-success" %></td>
+                 <td><%= link_to "Reject", admin_store_path(store, status: "suspended", initial_req: true), method: :put, class: "badge badge-warning" %></td>
                </tr>
              <% end %>
             </tbody>

--- a/spec/features/platform_admin/platform_admin_can_respond_to_a_store_creation_request_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_respond_to_a_store_creation_request_spec.rb
@@ -62,5 +62,25 @@ feature "As a logged in platform admin," do
         expect(user.roles).to include(store_admin_role)
       end
     end
+
+    feature "When I click 'Reject' for the pending company" do
+      scenario "it shows up in the 'active' tab, and the user that requested this store has a role of store admin" do
+        store_admin_role
+        click_link "Stores", href: "/admin/stores"
+        click_on "Reject"
+
+        within(".suspended_stores") do
+          expect(page).to have_content(store_1.id)
+          expect(page).to have_content(store_1.name)
+        end
+
+        within(".active_stores") do
+          expect(page).not_to have_content(store_1.id)
+          expect(page).not_to have_content(store_1.name)
+        end
+
+        expect(user.roles).to include(store_admin_role)
+      end
+    end
   end
 end

--- a/spec/features/platform_admin/platform_admin_can_respond_to_a_store_creation_request_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_respond_to_a_store_creation_request_spec.rb
@@ -64,7 +64,7 @@ feature "As a logged in platform admin," do
     end
 
     feature "When I click 'Reject' for the pending company" do
-      scenario "it shows up in the 'active' tab, and the user that requested this store has a role of store admin" do
+      scenario "it shows up in the 'suspended' tab, and the user that requested this store has a role of store admin" do
         store_admin_role
         click_link "Stores", href: "/admin/stores"
         click_on "Reject"

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -14,17 +14,31 @@ RSpec.describe Store do
       end
     end
 
-    describe "#update_status(status)" do
-      it "changes the status of a pending store to active" do
-        user = create(:user)
-        registered_user_role = create(:registered_user)
-        store_admin_role = create(:store_admin)
+    describe "#update_status(status, intial_req)" do
+      context "a store has been requested" do
+        it "changes the status of a pending store to active" do
+          user = create(:user)
+          registered_user_role = create(:registered_user)
+          store_admin_role = create(:store_admin)
 
-        user_roles = create(:user_role, user: user, role: registered_user_role, store: store)
-        store.update_status("active")
+          user_roles = create(:user_role, user: user, role: registered_user_role, store: store)
+          store.update_status("active", "true")
 
-        expect(store.status).to eq("active")
-        expect(user.roles).to include(store_admin_role)
+          expect(store.status).to eq("active")
+          expect(user.roles).to include(store_admin_role)
+        end
+
+        it "changes the status of a pending store to suspended" do
+          user = create(:user)
+          registered_user_role = create(:registered_user)
+          store_admin_role = create(:store_admin)
+
+          user_roles = create(:user_role, user: user, role: registered_user_role, store: store)
+          store.update_status("suspended", "true")
+
+          expect(store.status).to eq("suspended")
+          expect(user.roles).to include(store_admin_role)
+        end
       end
 
       context "a store is active" do


### PR DESCRIPTION
1 Pointer: 1 Reviewer

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153730464

#### What does this PR do?
Platform admin can reject pending store
In doing so, the associated user (of the store) is designated a role of store admin in case the store is ever activated in the future.

The Store model's #update_status method has been refactored to check whether a status change was from an initial request. If the status change was a result of an initial request, the user that submitted the request would be converted to a store admin.
(a #promote_creator_to_admin private was created to help with this)

#### Where should the reviewer start?
platform_admin_can_respond_to_a_store_creation_request_spec.rb

#### How should this be manually tested?
(copied and altered from PR related to approving store)
In console,
-Create a "Registered User", "Store Admin", and "Platform Admin" roles
-Create a registered user and platform admin (by assigning them roles)
On the website,
-As the registered user, create a store at "/stores/new"
-As the platform admin, go to your dashboard, click stores, and reject the store
-The store should show up under suspended
In console,
-The registered user should now have a role of "Store Admin"

#### Any background context you want to provide?
#### What are the relevant story numbers?
153730464

#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No

