### PR TITLE
PermissionsService PORO

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -41,6 +41,6 @@ class Admin::ItemsController < ApplicationController
   end
 
   def require_admin
-    render file: "/public/404" unless current_admin?
+    render file: "/public/404" unless current_user.current_admin?
   end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -39,8 +39,4 @@ class Admin::ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:title, :description, :price, :store_id, :category_id, :image)
   end
-
-  def require_admin
-    render file: "/public/404" unless current_user.current_admin?
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
-  before_action :set_cart, :set_categories
+  before_action :set_cart, :set_categories, :authorize!
 
   def current_user
     @user = User.find(session[:user_id]) if session[:user_id]
   end
 
-
-  def current_admin?
-    (current_user && current_user.admin?) ||
-      (current_user && current_user.platform_admin?)
+  def authorize!
+    current_permission = PermissionsService.new(current_user, params['controller'], params['action'])
+    not_found unless current_permission.authorized?
   end
-
 
   def set_cart
     @cart ||= Cart.new(session[:cart])
@@ -24,7 +22,7 @@ class ApplicationController < ActionController::Base
 
   private
     def require_admin
-      not_found unless current_admin?
+      not_found unless current_user.current_admin?
     end
 
     def not_found

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,7 +3,9 @@ class DashboardController < ApplicationController
   def index
     if current_user.nil?
       redirect_to login_path
-    else
+    elsif current_user.current_admin?
+      redirect_to admin_dashboard_index_path
+    elsif current_user.registered_user?
       @user = User.find(current_user.id)
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,7 +7,7 @@ class OrdersController < ApplicationController
   end
 
   def show
-    if current_admin?
+    if current_user.current_admin?
       @order = Order.find(params[:id])
     else
       @order = current_user.orders.find(params[:id])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,7 +30,7 @@ class SessionsController < ApplicationController
   def login_successful
     session[:user_id] = @user.id
     flash[:notice] = "Logged in as #{@user.first_name} #{@user.last_name}."
-    if @user.role == "admin"
+    if @user.current_admin?
       redirect_to admin_dashboard_index_path
     elsif @user.role == "default"
       redirect_to dashboard_index_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    if current_admin?
+    if current_user.current_admin?
       current_user.update(user_params)
       redirect_to admin_dashboard_index_path
     elsif current_user != nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,12 @@ class User < ApplicationRecord
     created_at.strftime('%b. %d, %Y')
   end
 
+  def current_admin?
+    return true if platform_admin?
+    return true if store_admin?
+    return true if store_manager?
+  end
+
   def platform_admin?
     roles.exists?(name: 'Platform Admin')
   end

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -1,0 +1,67 @@
+class PermissionsService
+  def initialize(user, controller, action)
+    @user       = user || User.new
+    @controller = controller
+    @action     = action
+  end
+
+  def authorized?
+    if user.platform_admin?
+      platform_admin_permissions
+    elsif user.store_admin?
+      store_admin_permissions
+    elsif user.store_manager?
+      store_manager_permissions
+    elsif user.registered_user?
+      registered_user_permissions
+    else
+      guest_user_permissions
+    end
+  end
+
+  private
+    attr_reader :user, :controller, :action
+
+    def platform_admin_permissions
+      return true if controller == 'main' && action == 'index'
+      return true if controller == 'sessions' && action.in?(%w(new create destroy))
+      return true if controller == 'admin/dashboard' && action == 'index'
+      return true if controller == 'users' && action.in?(%w(edit update))
+      return true if controller == 'admin/stores' && action.in?(%w(index update))
+    end
+
+    def store_admin_permissions
+      return true if controller == 'sessions' && action.in?(%w(new create destroy))
+      return true if controller == 'admin/dashboard' && action == 'index'
+      return true if controller == 'orders' && action.in?(%w(index show new))
+      return true if controller == 'admin/items' && action.in?(%w(index show new create edit update))
+    end
+
+    def store_manager_permissions
+      return true if controller == 'admin/dashboard' && action == 'index'
+      return true if controller == 'admin/items' && action.in?(%w(index show edit update))
+      return true if controller == 'orders' && action.in?(%w(index show update new))
+    end
+
+    def registered_user_permissions
+      return true if controller == 'main' && action == 'index'
+      return true if controller == 'sessions' && action.in?(%w(new create destroy))
+      return true if controller == 'dashboard' && action == 'index'
+      return true if controller == 'orders' && action.in?(%w(index show new))
+      return true if controller == 'stores' && action.in?(%w(show new create))
+      return true if controller == 'user/stores' && action.in?(%w(index))
+      return true if controller == 'carts' && action.in?(%w(index create))
+    end
+
+    def guest_user_permissions
+      return true if controller == 'main' && action == 'index'
+      return true if controller == 'dashboard' && action == 'index'
+      return true if controller == 'sessions' && action.in?(%w(new create destroy))
+      return true if controller == 'items' && action.in?(%w(index show))
+      return true if controller == 'orders' && action.in?(%w(new))
+      return true if controller == 'carts' && action.in?(%w(index create destroy update))
+      return true if controller == 'categories' && action.in?(%w(index show))
+      return true if controller == 'stores' && action.in?(%w(index show))
+      return true if controller == 'users' && action.in?(%w(new create))
+    end
+end

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -23,45 +23,39 @@ class PermissionsService
     attr_reader :user, :controller, :action
 
     def platform_admin_permissions
-      return true if controller == 'main' && action == 'index'
-      return true if controller == 'sessions' && action.in?(%w(new create destroy))
-      return true if controller == 'admin/dashboard' && action == 'index'
       return true if controller == 'users' && action.in?(%w(edit update))
       return true if controller == 'admin/stores' && action.in?(%w(index update))
+      store_admin_permissions
     end
 
     def store_admin_permissions
-      return true if controller == 'sessions' && action.in?(%w(new create destroy))
-      return true if controller == 'admin/dashboard' && action == 'index'
-      return true if controller == 'orders' && action.in?(%w(index show new))
-      return true if controller == 'admin/items' && action.in?(%w(index show new create edit update))
+      return true if controller == 'admin/items' && action.in?(%w(new create))
+      store_manager_permissions
     end
 
     def store_manager_permissions
       return true if controller == 'admin/dashboard' && action == 'index'
       return true if controller == 'admin/items' && action.in?(%w(index show edit update))
-      return true if controller == 'orders' && action.in?(%w(index show update new))
+      return true if controller == 'orders' && action.in?(%w(update new))
+      registered_user_permissions
     end
 
     def registered_user_permissions
-      return true if controller == 'main' && action == 'index'
-      return true if controller == 'sessions' && action.in?(%w(new create destroy))
-      return true if controller == 'dashboard' && action == 'index'
-      return true if controller == 'orders' && action.in?(%w(index show new))
-      return true if controller == 'stores' && action.in?(%w(show new create))
       return true if controller == 'user/stores' && action.in?(%w(index))
-      return true if controller == 'carts' && action.in?(%w(index create))
+      return true if controller == 'stores' && action.in?(%w(index show new create))
+      return true if controller == 'orders' && action.in?(%w(index show))
+      guest_user_permissions
     end
 
     def guest_user_permissions
       return true if controller == 'main' && action == 'index'
-      return true if controller == 'dashboard' && action == 'index'
       return true if controller == 'sessions' && action.in?(%w(new create destroy))
-      return true if controller == 'items' && action.in?(%w(index show))
-      return true if controller == 'orders' && action.in?(%w(new))
-      return true if controller == 'carts' && action.in?(%w(index create destroy update))
-      return true if controller == 'categories' && action.in?(%w(index show))
+      return true if controller == 'dashboard' && action == 'index'
       return true if controller == 'stores' && action.in?(%w(index show))
+      return true if controller == 'categories' && action.in?(%w(index show))
+      return true if controller == 'items' && action.in?(%w(index show))
+      return true if controller == 'carts' && action.in?(%w(index create destroy update))
+      return true if controller == 'orders' && action.in?(%w(new))
       return true if controller == 'users' && action.in?(%w(new create))
     end
 end

--- a/spec/features/admin/authentication/admin_can_update_their_account_but_not_user_account_spec.rb
+++ b/spec/features/admin/authentication/admin_can_update_their_account_but_not_user_account_spec.rb
@@ -1,14 +1,19 @@
 require "rails_helper"
 
 describe "As a logged in Admin" do
-  let(:admin) { create(:user, role: "admin", email: "admin@example.com")}
+  let(:admin) { create(:user, email: "admin@example.com")}
+  let(:role) { create(:platform_admin) }
 
   it "I can modify my account data" do
+    admin.roles << role
+
     login_user(admin.email, admin.password)
+
     new_email_address = "kramer@example.com"
     new_password      = "cosmo"
 
     visit admin_dashboard_index_path
+
     click_on "Update Account"
     fill_in "user[email]", with: new_email_address
     fill_in "user[password]", with: new_password
@@ -21,17 +26,23 @@ describe "As a logged in Admin" do
 
   it "But I cannot modify any other user’s account data" do
     allow_any_instance_of(ApplicationController).to receive(:current_user). and_return(admin)
-    user = create(:user)
+    user = create(:user, first_name: 'Emma')
+    role = create(:registered_user)
+    admin.roles << role
+    user.roles << role
 
     visit dashboard_index_path(user)
 
-    expect(page).not_to have_content("Update account")
+    expect(page).not_to have_content('Emma')
+    expect(page).to have_content('Gob')
   end
 
   it "returns a welcome message for admins" do
     allow_any_instance_of(ApplicationController).to receive(:current_user). and_return(admin)
+    admin.roles << role
+
     visit admin_dashboard_index_path
-    expect(page).to have_content("You're logged in as an Administrator")
+    expect(page).to have_content("You're logged in as a Platform Admin.")
   end
 
   it "returns a 404 when a non-admin visits the admin dashboard" do

--- a/spec/features/admin/authentication/admin_can_visit_dashboard_spec.rb
+++ b/spec/features/admin/authentication/admin_can_visit_dashboard_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
   feature "admin dashboard" do
     feature "admin can visit the admin dashboard" do
       scenario "I will see a heading on the page that says Admin Dashboard" do
-        admin_user = create(:admin)
+        admin_user = create(:user)
+        role = create(:platform_admin)
+        admin_user.roles << role
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_user)
 
@@ -39,18 +41,20 @@ feature "as an Admin" do
   describe "when I log into my account" do
 
     it "I am redirected to the Admin Dashboard" do
-      admin = create(:admin)
+      admin = create(:user)
+      role = create(:platform_admin)
+      admin.roles << role
 
       visit login_path
 
-
       fill_in "session[email]", with: admin.email
       fill_in "session[password]", with: admin.password
+
       within(".action") do
         click_on("Login")
       end
 
-      expect(page).to have_content("You're logged in as an Administrator.")
+      expect(page).to have_content("You're logged in as a Platform Admin.")
 
       expect(current_path).to eq(admin_dashboard_index_path)
     end

--- a/spec/features/admin/items/admin_can_create_items_spec.rb
+++ b/spec/features/admin/items/admin_can_create_items_spec.rb
@@ -1,11 +1,19 @@
 require 'rails_helper'
 
 RSpec.feature "Admin item creation" do
+  let(:admin) { create(:user) }
+  let(:role) { create(:store_admin) }
+  let(:store) { create(:store) }
+  let(:category) { create(:category) }
+
+  before :each do
+    store
+    category
+  end
+
   context "As an authenticated admin" do
     it "I can create an item" do
-      admin = build(:admin)
-      store = create(:store)
-      category = create(:category)
+      admin.roles << role
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit admin_items_path
@@ -24,10 +32,7 @@ RSpec.feature "Admin item creation" do
     end
 
     it "I can create an item without an image and it defaults" do
-      admin = build(:admin)
-      store = create(:store)
-      category = create(:category)
-
+      admin.roles << role
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
       visit admin_items_path
 

--- a/spec/features/admin/items/admin_can_visit_admin_items_and_edit_an_item_spec.rb
+++ b/spec/features/admin/items/admin_can_visit_admin_items_and_edit_an_item_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'an admin can visit admin dashboard' do
     it 'when clicked that link should be the admin item index with admin functionality' do
       create(:item)
       admin = create(:admin)
+      role = create(:store_admin)
+      admin.roles << role
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit admin_items_path

--- a/spec/features/admin/platform_admin_can_view_their_dashboard_spec.rb
+++ b/spec/features/admin/platform_admin_can_view_their_dashboard_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.feature 'As an authenticated platform admin' do
+  let(:role) { create(:platform_admin) }
+  let(:admin) { create(:user) }
+
+  scenario 'I can view my admin/dashboard' do
+    admin.roles << role
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit admin_dashboard_index_path
+
+    expect(current_path).to eq('/admin/dashboard')
+    expect(page).to have_content('Admin Dashboard')
+    expect(page).to have_content("You're logged in as a Platform Admin.")
+  end
+end

--- a/spec/features/admin/views/admin_can_see_all_orders_spec.rb
+++ b/spec/features/admin/views/admin_can_see_all_orders_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature "Admin Orders" do
-  let(:admin) { create(:admin) }
+  let(:admin) { create(:user) }
+  let(:role) { create(:store_manager) }
 
   before(:each) do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    admin.roles << role
   end
 
   context "As an admin and two orders in the database" do

--- a/spec/features/admin/views/admin_can_visit_dashboard_and_see_all_items_with_edit_button_spec.rb
+++ b/spec/features/admin/views/admin_can_visit_dashboard_and_see_all_items_with_edit_button_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe 'an admin can visit admin dashboard' do
   describe 'and see a link for all items' do
     it 'when clicked that link should be the admin item index with admin functionality' do
-      admin_user = create(:admin)
+      admin_user = create(:user)
+      role = create(:store_manager)
+      admin_user.roles << role
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_user)
 
       category = create(:category)

--- a/spec/features/admin/views/admin_views_an_individual_order_spec.rb
+++ b/spec/features/admin/views/admin_views_an_individual_order_spec.rb
@@ -4,6 +4,8 @@ feature "Admin can view individual order pages" do
   scenario "when I visit an valid order page" do
     user = create(:user, first_name: "Gob", last_name: "Bluth")
     admin = create(:admin)
+    role = create(:store_admin)
+    admin.roles << role
     item_1 = create(:item, price: 11.00)
     item_2 = create(:item, price: 10.00)
     items_with_quantity_for_order = [ {item_1 => 1}, {item_2 => 2} ]

--- a/spec/features/user/authentication/unauthentic_user_cannot_view_another_users_data_spec.rb
+++ b/spec/features/user/authentication/unauthentic_user_cannot_view_another_users_data_spec.rb
@@ -1,17 +1,9 @@
 require 'rails_helper'
 
 RSpec.feature "Unauthenticated users security" do
-  # let(:user) { create(:registered_user) }
-  # let(:order) { create(:order, user: user)}
-  # let(:unicorn_onesie_1) { create(:item) }
-
-  before(:each) do
-    user = create(:user)
-    role = create(:registered_user)
-    user.roles << role
-    @order = create(:order, user: user)
-    @unicorn_onesie_1 = create(:item)
-  end
+  let(:user) { create(:user) }
+  let(:order) { create(:order, user: user)}
+  let(:unicorn_onesie_1) { create(:item) }
 
   context "As an unauthenticated user" do
     it "I cannot view another user’s private data" do
@@ -20,12 +12,12 @@ RSpec.feature "Unauthenticated users security" do
       expect(current_path).to eq(login_path)
 
       expect {
-        visit order_path(@order)
+        visit order_path(order)
       }.to raise_exception(ActionController::RoutingError)
     end
 
     it "I should be redirected to login/create account when I try to check out" do
-      visit item_path(@unicorn_onesie_1)
+      visit item_path(unicorn_onesie_1)
 
       click_on "Add to cart"
 

--- a/spec/features/user/authentication/unauthentic_user_cannot_view_another_users_data_spec.rb
+++ b/spec/features/user/authentication/unauthentic_user_cannot_view_another_users_data_spec.rb
@@ -1,20 +1,27 @@
 require 'rails_helper'
 
 RSpec.feature "Unauthenticated users security" do
+  # let(:user) { create(:registered_user) }
+  # let(:order) { create(:order, user: user)}
+  # let(:unicorn_onesie_1) { create(:item) }
+
   before(:each) do
     user = create(:user)
+    role = create(:registered_user)
+    user.roles << role
     @order = create(:order, user: user)
     @unicorn_onesie_1 = create(:item)
   end
+
   context "As an unauthenticated user" do
     it "I cannot view another user’s private data" do
       visit dashboard_index_path
 
       expect(current_path).to eq(login_path)
 
-      visit order_path(@order)
-
-      expect(current_path).to eq(login_path)
+      expect {
+        visit order_path(@order)
+      }.to raise_exception(ActionController::RoutingError)
     end
 
     it "I should be redirected to login/create account when I try to check out" do

--- a/spec/features/user/authentication/user_can_be_authenticated_spec.rb
+++ b/spec/features/user/authentication/user_can_be_authenticated_spec.rb
@@ -7,6 +7,8 @@ describe "And when I click “Login” I should be on the “/login page”" do
       describe "Then my current page should be “/dashboard”" do
         it " And I should see a message in the navbar that says “Logged in as SOME_USER” as well as my profile information and I  a link for “Logout, but no link for log_in”" do
           user = create(:user)
+          role = create(:registered_user)
+          user.roles << role
 
           login_user(user.email, user.password)
 

--- a/spec/features/user/authentication/user_can_logout_spec.rb
+++ b/spec/features/user/authentication/user_can_logout_spec.rb
@@ -3,6 +3,9 @@
 RSpec.describe "As a visitor I can login" do
 	it "as a user I can log out" do
 		user = create(:user)
+		role = create(:registered_user)
+		user.roles << role
+
 		visit '/'
 		click_on 'Login'
 		fill_in "session[email]", with: user.email

--- a/spec/features/user/authentication/user_cannot_view_another_users_data_spec.rb
+++ b/spec/features/user/authentication/user_cannot_view_another_users_data_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature "Authenticated users security" do
     scenario "I cannot view another user's order" do
       chino = create(:user, first_name: "Chino")
       khaki = create(:user, first_name: "Khaki")
+      role = create(:registered_user)
+      khaki.roles << role
       stub_logged_in_user(khaki)
 
       order = create(:order, user: chino)

--- a/spec/features/user/items/user_can_place_orders_spec.rb
+++ b/spec/features/user/items/user_can_place_orders_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature "User can place an order" do
   it "and see the message 'order was successfully placed'" do
 
     user = create(:user)
+    role = create(:registered_user)
+    user.roles << role
     category = create(:category)
     item = create(:item, category: category)
 

--- a/spec/features/user/views/user_can_visit_order_show_page_spec.rb
+++ b/spec/features/user/views/user_can_visit_order_show_page_spec.rb
@@ -4,6 +4,8 @@ describe "As a user" do
   describe "visits /orders" do
     it "can see all past orders" do
       user = create(:user)
+      role = create(:registered_user)
+      user.roles << role
       item = create(:item, price: 5.00)
       items_with_quantity = [ {item => 2} ]
       order = create(:order_with_items, user: user, items_with_quantity: items_with_quantity)

--- a/spec/features/user/views/user_visits_orders_and_can_see_their_past_orders_spec.rb
+++ b/spec/features/user/views/user_visits_orders_and_can_see_their_past_orders_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 describe "As a user" do
+  let(:role) { create(:registered_user) }
   describe "visits /orders" do
     it "can see all past orders" do
       user = create(:user)
+      user.roles << role
       create(:order, user: user)
       item = create(:item, price: 5.00)
       items_with_quantity = [ {item => 2} ]
@@ -11,7 +13,7 @@ describe "As a user" do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit '/orders'
-      
+
       expect(page).to have_css(".order", count: 2)
 
       within("#order-#{order_1.id}") do


### PR DESCRIPTION
### Note:
This is a fairly large PR and many files were changed, unsure how many people need to review it but please review thoroughly.

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153707221

#### What does this PR do?
Enables a 'Platform Admin' user being able to log in under the new implementation. Ticket subsequently called for the PermissionsService PORO to be built out, which required the conversion of all other users to turn over to the new code for tests to pass - resulting in all permissions being defined in the end for all tests to pass.

#### Where should the reviewer start?
Start in the 'platform admin can view their dashboard spec'

#### Any background context you want to provide?
There were some methods from the old code that were modified to apply to the new feature.

#### What are the relevant story numbers?
153707221

#### Questions:
  - Do Migrations Need to be ran?
Maybe?
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
New rake tasks populating role and user_role from previous PR must be implemented

