### PR TITLE
Store Manager and Store Admin can manage item information

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ItemsController < ApplicationController
   before_action :require_admin
   def index
-    @items = Item.all
+    @items = Item.all_for_admin(current_user)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,4 +21,12 @@ class Item < ApplicationRecord
     group(:title).joins(:orders).group(:status).count
   end
 
+  def self.all_for_admin(user)
+    if user.platform_admin?
+      Item.all
+    else
+      where(store: user.stores)
+    end
+  end
+
 end

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -7,9 +7,9 @@
       <div class="center-block">
         <div class="card border-white" style="width: 7rem;">
           <%= image_tag item.image.url(:medium), class: "card-img-top" %>
+          <h2>Store: <%= item.store.name %></h2>
           <div class="card-body">
             <center><p class='small'><strong><%= link_to item.title, item_path(item) %></strong></p>
-              <!-- <p>Description: <%= item.description %></p> -->
               <footer>
                 <p class='small'>Price: $<%= item.price %></p>
                 <p><%= link_to "Edit", edit_admin_item_path(item), class: "badge badge-info"  %></p>

--- a/spec/features/admin/items/admin_can_create_items_spec.rb
+++ b/spec/features/admin/items/admin_can_create_items_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Admin item creation" do
 
   context "As an authenticated admin" do
     it "I can create an item" do
-      admin.roles << role
+      create(:user_role, user: admin, role: role, store: store)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit admin_items_path
@@ -32,7 +32,7 @@ RSpec.feature "Admin item creation" do
     end
 
     it "I can create an item without an image and it defaults" do
-      admin.roles << role
+      create(:user_role, user: admin, role: role, store: store)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
       visit admin_items_path
 

--- a/spec/features/admin/items/admin_can_visit_admin_items_and_edit_an_item_spec.rb
+++ b/spec/features/admin/items/admin_can_visit_admin_items_and_edit_an_item_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-
 RSpec.describe 'an admin can visit admin dashboard' do
   describe 'and see a link for all items' do
     it 'when clicked that link should be the admin item index with admin functionality' do
-      create(:item)
+      store = create(:store)
+      create(:item, store: store)
       admin = create(:admin)
       role = create(:store_admin)
-      admin.roles << role
+      create(:user_role, user: admin, role: role, store: store)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit admin_items_path

--- a/spec/features/admin/views/admin_can_visit_dashboard_and_see_all_items_with_edit_button_spec.rb
+++ b/spec/features/admin/views/admin_can_visit_dashboard_and_see_all_items_with_edit_button_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe 'an admin can visit admin dashboard' do
   describe 'and see a link for all items' do
     it 'when clicked that link should be the admin item index with admin functionality' do
+      store = create(:store, status: "active")
       admin_user = create(:user)
       role = create(:store_manager)
-      admin_user.roles << role
+      create(:user_role, user: admin_user, role: role, store: store)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_user)
 
       category = create(:category)
-      items = create_list(:item, 2, category: category)
+      items = create_list(:item, 2, category: category, store: store)
       item_one = items.first
       item_two = items.last
 

--- a/spec/features/store_admin/store_admin_can_change_item_information_spec.rb
+++ b/spec/features/store_admin/store_admin_can_change_item_information_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+feature "As a store manager" do
+  let(:store_admin) { create(:user) }
+  let(:store_admin_role) { create(:store_admin) }
+  let(:store) { create(:store, status: "active") }
+  let(:store_item) { create(:item, store: store) }
+
+  scenario "I can change item information for a store that I manage" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_admin)
+    create(:user_role, user: store_admin, role: store_admin_role, store: store)
+    store_item
+
+    visit admin_items_path
+    expect(page).to have_content(store.name)
+
+    click_on "Edit"
+
+    fill_in "item[title]", with: "Learning to Jump"
+    fill_in "item[description]", with: "Improve your vertical leap"
+    fill_in "item[price]", with: "32.52"
+    page.attach_file("item[image]", testing_image)
+    click_on "Update"
+
+    expect(page).to have_content("Learning to Jump")
+    expect(page).to have_content("$32.52")
+  end
+
+  scenario "I don't see an item if it is not in a store I manage" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_admin)
+    create(:user_role, user: store_admin, role: store_admin_role, store: store)
+    store_item
+    store_2 = create(:store, status: "active")
+    store_item_2 = create(:item, store: store_2)
+
+    visit admin_items_path
+
+    expect(page).to have_content(store_item.title)
+    expect(page).to_not have_content(store_item_2.title)
+  end
+end

--- a/spec/features/store_manager/store_manager_can_edit_an_item_spec.rb
+++ b/spec/features/store_manager/store_manager_can_edit_an_item_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+feature "As a store manager" do
+  let(:store_manager) { create(:user) }
+  let(:store_manager_role) { create(:store_manager) }
+  let(:store) { create(:store, status: "active") }
+  let(:store_item) { create(:item, store: store) }
+
+  scenario "I can change item information for a store that I manage" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_manager)
+    create(:user_role, user: store_manager, role: store_manager_role, store: store)
+    store_item
+
+    visit admin_items_path
+    expect(page).to have_content(store.name)
+
+    click_on "Edit"
+
+    fill_in "item[title]", with: "Learning Layups"
+    fill_in "item[description]", with: "Improve your basketball skills"
+    fill_in "item[price]", with: "12.09"
+    page.attach_file("item[image]", testing_image)
+    click_on "Update"
+
+    expect(page).to have_content("Learning Layups")
+    expect(page).to have_content("$12.09")
+  end
+
+  scenario "I don't see an item if it is not in a store I manage" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_manager)
+    create(:user_role, user: store_manager, role: store_manager_role, store: store)
+    store_item
+    store_2 = create(:store, status: "active")
+    store_item_2 = create(:item, store: store_2)
+
+    visit admin_items_path
+
+    expect(page).to have_content(store_item.title)
+    expect(page).to_not have_content(store_item_2.title)
+  end
+end

--- a/spec/models/items_spec.rb
+++ b/spec/models/items_spec.rb
@@ -57,4 +57,31 @@ describe Item do
       expect(item).to respond_to(:orders)
     end
   end
+
+  describe ".class_methods" do
+    describe ".all_for_admin(user)" do
+      it "returns all items for a platform_admin" do
+        store = create(:store)
+        items = create_list(:item, 3, store: store)
+        platform_admin = create(:user)
+        platform_admin_role = create(:platform_admin)
+        create(:user_role, user: platform_admin, role: platform_admin_role)
+
+        expect(Item.all_for_admin(platform_admin)).to eq(items)
+      end
+
+      it "returns items associated with a store_admin/store_manager and does not return other items" do
+        stores = create_list(:store, 2)
+        items_store1 = create_list(:item, 2, store: stores.first)
+        item_store2 = create(:item, store: stores.last)
+        store_admin = create(:user)
+        store_admin_role = create(:store_admin)
+        create(:user_role, user: store_admin, role: store_admin_role, store: stores.first)
+
+        expect(Item.all_for_admin(store_admin)).to include(items_store1.first)
+        expect(Item.all_for_admin(store_admin)).to include(items_store1.last)
+        expect(Item.all_for_admin(store_admin)).to_not include(item_store2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## two 1 point stories: 1 reviewer?

#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153614689
https://www.pivotaltracker.com/story/show/153568563

#### What does this PR do?
This PR only shows items associated with specific stores that a user is either a store_manager or a store_admin. A platform admin will still see all items.

If a store_manager/admin has multiple stores, all of the items will show up, so I added a store name to each item.

It maintains the original functionality to change item information.

#### Where should the reviewer start?
app/controllers/admin/items_controller.rb to see the method that scopes the items to a specific user.
item.rb to see the method that limits the collection of items.

#### How should this be manually tested?
log in as a store_admin or a store_manager and see if you can change the status of an order.

#### Any background context you want to provide?
#### What are the relevant story numbers?
153614689
153568563
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No

