### PR TITLE
Store Manager & Store Admin can manage orders

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,9 +3,9 @@ class Admin::DashboardController < ApplicationController
 
   def index
     if params[:status] == "ordered" || params[:status] == "paid" || params[:status] == "cancelled" || params[:status] == "completed"
-      @orders = Order.filter_by_status(params[:status])
+      @orders = Order.filter_by_status(params[:status], current_user)
     else
-      @orders = Order.all
+      @orders = Order.all_for_admin(current_user)
     end
     flash[:notice] = "You're logged in as #{current_user.highest_role}."
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ApplicationRecord
   validates :status, presence: true
   has_many :order_items
   has_many :items, through: :order_items
+  belongs_to :store
 
   enum status: ["ordered", "paid", "cancelled", "completed"]
 
@@ -18,8 +19,12 @@ class Order < ApplicationRecord
     group(:status).count
   end
 
-  def self.filter_by_status(status)
-    where(status: status)
+  def self.filter_by_status(status, user)
+    if user.platform_admin?
+      where(status: status)
+    else
+      where(store: user.stores).where(status: status)
+    end
   end
 
   def self.count_of_completed_orders
@@ -29,4 +34,13 @@ class Order < ApplicationRecord
   def self.shop_total_gross
 		where(status: :completed).joins(:items).sum(:price)
   end
+
+  def self.all_for_admin(user)
+    if user.platform_admin?
+      Order.all
+    else
+      where(store: user.stores)
+    end
+  end
+
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -2,6 +2,7 @@ class Store < ApplicationRecord
   has_many :user_roles
   has_many :users, through: :user_roles
   has_many :items
+  has_many :orders
 
   before_validation :generate_url
 

--- a/app/services/order_creation_service.rb
+++ b/app/services/order_creation_service.rb
@@ -14,7 +14,8 @@ class OrderCreationService
 
     def self.create_orders(orders_data, user)
       orders_data.map do |order_details|
-        order = Order.create(status: "ordered", user: user)
+        store = order_details[0][0].store
+        order = Order.create(status: "ordered", user: user, store: store)
         create_order_items(order, order_details)
         order.update_total_price
         order

--- a/db/migrate/20171219002457_add_store_to_order.rb
+++ b/db/migrate/20171219002457_add_store_to_order.rb
@@ -1,0 +1,5 @@
+class AddStoreToOrder < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :orders, :store, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171216020612) do
+ActiveRecord::Schema.define(version: 20171219002457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,8 +47,10 @@ ActiveRecord::Schema.define(version: 20171216020612) do
     t.integer "quantity"
     t.float "unit_price"
     t.float "total_price"
+    t.bigint "store_id"
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["store_id"], name: "index_order_items_on_store_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -61,6 +63,8 @@ ActiveRecord::Schema.define(version: 20171216020612) do
     t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.float "total_price"
+    t.bigint "store_id"
+    t.index ["store_id"], name: "index_orders_on_store_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -101,6 +105,8 @@ ActiveRecord::Schema.define(version: 20171216020612) do
   add_foreign_key "items", "stores"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "stores"
+  add_foreign_key "orders", "stores"
   add_foreign_key "orders", "users"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "stores"

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     status 1
     total_price { rand(1..100) }
     user
+    store
 
     transient do
       items_with_quantity [{create(:item) => 1}]

--- a/spec/features/admin/views/admin_can_see_all_orders_spec.rb
+++ b/spec/features/admin/views/admin_can_see_all_orders_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Admin Orders" do
   let(:admin) { create(:user) }
-  let(:role) { create(:store_manager) }
+  let(:role) { create(:platform_admin) }
 
   before(:each) do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)

--- a/spec/features/store_admin/store_admin_can_manage_orders_spec.rb
+++ b/spec/features/store_admin/store_admin_can_manage_orders_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.feature "As a store_admin" do
+  let(:store_admin) { create(:user) }
+  let(:store_admin_role) { create(:store_admin) }
+  let(:store) { create(:store, status: "active") }
+
+  before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_admin)
+    create(:user_role, user: store_admin, role: store_admin_role, store: store)
+  end
+
+  context "with two orders for my store" do
+    let!(:order_1) { create(:order, status: "ordered", store: store) }
+    let!(:order_2) { create(:order, status: "ordered", store: store) }
+
+    it "I can change the status of orders" do
+      visit admin_dashboard_index_path
+
+      within(".order-#{order_2.id}") do
+        click_on("Cancel")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_2.id}") do
+        expect(page).to have_content("Cancelled")
+      end
+
+      within(".order-#{order_1.id}") do
+        click_on("Mark as Paid")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_1.id}") do
+        within(".status") do
+          expect(page).to have_content("Paid")
+        end
+      end
+
+      within(".order-#{order_1.id}") do
+        click_on("Mark as Completed")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_1.id}") do
+        within(".status") do
+          expect(page).to have_content("Completed")
+        end
+      end
+    end
+
+    context "and an order for a different store" do
+      scenario "I don't see the other store's order" do
+        other_store = create(:store)
+        other_order = create(:order, store: other_store)
+
+        visit admin_dashboard_index_path
+
+        expect(page).to have_css(".order-#{order_1.id}")
+        expect(page).to_not have_css(".order-#{other_order.id}")
+      end
+    end
+  end
+end

--- a/spec/features/store_manager/store_manager_can_manage_orders_spec.rb
+++ b/spec/features/store_manager/store_manager_can_manage_orders_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.feature "As a store_manager" do
+  let(:store_manager) { create(:user) }
+  let(:store_manager_role) { create(:store_manager) }
+  let(:store) { create(:store, status: "active") }
+
+  before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_manager)
+    create(:user_role, user: store_manager, role: store_manager_role, store: store)
+  end
+
+  context "with two orders for my store" do
+    let!(:order_1) { create(:order, status: "ordered", store: store) }
+    let!(:order_2) { create(:order, status: "ordered", store: store) }
+
+    it "I can change the status of orders" do
+      visit admin_dashboard_index_path
+
+      within(".order-#{order_2.id}") do
+        click_on("Cancel")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_2.id}") do
+        expect(page).to have_content("Cancelled")
+      end
+
+      within(".order-#{order_1.id}") do
+        click_on("Mark as Paid")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_1.id}") do
+        within(".status") do
+          expect(page).to have_content("Paid")
+        end
+      end
+
+      within(".order-#{order_1.id}") do
+        click_on("Mark as Completed")
+      end
+
+      expect(current_path).to eq(admin_dashboard_index_path)
+
+      within(".order-#{order_1.id}") do
+        within(".status") do
+          expect(page).to have_content("Completed")
+        end
+      end
+    end
+
+    context "and an order for a different store" do
+      scenario "I don't see the other store's order" do
+        other_store = create(:store)
+        other_order = create(:order, store: other_store)
+
+        visit admin_dashboard_index_path
+
+        expect(page).to have_css(".order-#{order_1.id}")
+        expect(page).to_not have_css(".order-#{other_order.id}")
+      end
+    end
+  end
+end

--- a/spec/models/items_spec.rb
+++ b/spec/models/items_spec.rb
@@ -67,7 +67,9 @@ describe Item do
         platform_admin_role = create(:platform_admin)
         create(:user_role, user: platform_admin, role: platform_admin_role)
 
-        expect(Item.all_for_admin(platform_admin)).to eq(items)
+        expect(Item.all_for_admin(platform_admin)).to include(items.first)
+        expect(Item.all_for_admin(platform_admin)).to include(items[1])
+        expect(Item.all_for_admin(platform_admin)).to include(items.last)
       end
 
       it "returns items associated with a store_admin/store_manager and does not return other items" do


### PR DESCRIPTION
#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153614655
https://www.pivotaltracker.com/story/show/153614688

#### What does this PR do?
This PR adds store_id to the orders table and creates the appropriate relationships (store has_many orders; order belongs_to a store).

This PR only shows the orders from a user's associated stores (store_manager, store_admin) and allows them to change the status.

#### Where should the reviewer start?
spec/features/store_admin/store_admin_can_manage_orders_spec.rb 

app/controllers/admin/dashboard_controller.rb

Then the Order model and corresponding order_spec.rb

#### How should this be manually tested?
Create a couple orders for a store and then visit admin/dashboard. You should only see the orders for this store. 

#### Any background context you want to provide?
#### What are the relevant story numbers?
153614655
153614688
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
YES!
  - Do Environment Variables need to be set?
no.
  - Any other deploy steps?
no.
