### PR TITLE
Limit the stores in dropdown menu to only be associated with the user

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -6,7 +6,7 @@ class Admin::ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    @stores = Store.all
+    @stores = Store.all_for_admin(current_user)
     @categories = Category.all
   end
 
@@ -30,7 +30,7 @@ class Admin::ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    @stores = Store.all
+    @stores = Store.all_for_admin(current_user)
     @categories = Category.all
   end
 

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -31,6 +31,14 @@ class Store < ApplicationRecord
     update(status: status)
   end
 
+  def self.all_for_admin(user)
+    if user.platform_admin?
+      Store.all
+    else
+      user.stores
+    end
+  end
+
   private
 
     def generate_url


### PR DESCRIPTION
#### Pivotal URL: 
https://www.pivotaltracker.com/story/show/153804957

#### What does this PR do?
This PR limits the store dropdown to only the stores associated with the current_user when trying to create a new item for a store.

#### Where should the reviewer start?
app/controllers/admin/items_controller.rb

#### How should this be manually tested?
Start the server and log in as a store_admin or store_manager with a store. Click on 'View Items', and then create a new item. In the dropdown, there should only be stores that you're associated with.

If you're logged in as a platform admin, you should see all the stores on the platform.

#### Any background context you want to provide?
#### What are the relevant story numbers?
153804957
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No
