### PR TITLE
Add first store to initial ordes

### DIFF
--- a/lib/tasks/add_store_to_order.rake
+++ b/lib/tasks/add_store_to_order.rake
@@ -1,0 +1,14 @@
+desc "Adds store to orders 1-55 which are the orders from the original store"
+task associate_store_order: :environment do
+  orders = Order.where(id: 1..55, store_id: nil)
+  store = Store.find_by(name: "Little Shop of Funsies")
+
+  orders.each do |order|
+    if order.store
+      puts "Order ##{order.id} already has a store."
+    else
+      order.update(store: store)
+      puts "Order ##{order.id} now is associated to #{store.name} items."
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153804679

#### What does  this PR do?
Create a rake task to populate store_id for current orders

#### Where should the reviewer start?
#### How should this be manually tested?
After rake task, in console,
Order.where(store: nil).count == 0
  -should return true
#### Any background context you want to provide?
#### What are the relevant story numbers?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
  - Do Environment Variables need to be set?
  - Any other deploy steps?
YES
```rake associate_store_order```