### PR TITLE
Associate original admin with original store through UserRole record

### DIFF
--- a/lib/tasks/original_store_owner.rake
+++ b/lib/tasks/original_store_owner.rake
@@ -1,0 +1,7 @@
+desc "Associate the original admin with the original store"
+task original_store_admin_association: :environment do
+  original_admin = User.find_by(first_name: "Mary", email: "mary@example.com")
+  store_admin = Role.find_by(name: "Store Admin")
+  store = Store.find_by(name: "Little Shop of Funsies")
+  UserRole.find_or_create_by(user: original_admin, role: store_admin, store: store)
+end


### PR DESCRIPTION
#### Pivotal URL:
https://www.pivotaltracker.com/story/show/153725768
#### What does this PR do?
this PR creates the a rake task to associate the original admin (first_name: "Mary", email: "mary@example.com") with the original store (name: "Little Shop of Funsies") through a UserRole record (role will be store_admin).

#### Where should the reviewer start?
the rake task
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant story numbers?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
`$ rake original_store_admin_association`